### PR TITLE
[ISSUE-32] Front-end Planning

### DIFF
--- a/documentation/milestones/individual_milestones/api_planning.md
+++ b/documentation/milestones/individual_milestones/api_planning.md
@@ -121,7 +121,7 @@ Some factors to consider are:
 ### Definition of done
 <!-- Required -->
 
-- [ ] The tools and services chosen have been authorized under the Grants.gov ATO (Authority to Operate)
+- [ ] The tools and services chosen have been authorized under the Grants.gov ATO (Authority to Operate) and/or are FedRAMP approved
 - [ ] An ADR has been recorded and published to `main` for each of the following choices:
   - [ ] API Language
   - [ ] API Framework

--- a/documentation/milestones/individual_milestones/api_planning.md
+++ b/documentation/milestones/individual_milestones/api_planning.md
@@ -167,6 +167,8 @@ The following metrics should be tracked about the tools selected within this met
 ### Destination for live updating metrics
 <!-- Required -->
 
+Page on the public wiki. **Note:** This will likely change once we deliver [the Public Measurement Dashboard milestone](../milestone_short_descriptions.md#public-measurement-dashboards)
+
 ## Planning
 
 ### Assumptions & dependencies

--- a/documentation/milestones/individual_milestones/communication_platforms.md
+++ b/documentation/milestones/individual_milestones/communication_platforms.md
@@ -2,7 +2,7 @@
 
 | Field           | Value                                                                |
 | --------------- | -------------------------------------------------------------------- |
-| Document Status | Final Draft                                                          |
+| Document Status | Completed                                                         |
 | Epic Link       | [Issue 47](https://github.com/HHS/grants-api/issues/47)              |
 | Epic Dashboard  | [Milestone Roadmap](https://github.com/orgs/HHS/projects/12/views/4) |
 | Target Release  | 2023-08-23                                                           |

--- a/documentation/milestones/individual_milestones/frontend_planning.md
+++ b/documentation/milestones/individual_milestones/frontend_planning.md
@@ -1,51 +1,52 @@
 # Front-end Planning
 
-| Field           | Value          |
-| --------------- | -------------- |
-| Document Status | Draft          |
-| Epic Link       | TODO: Add Link |
-| Epic Dashboard  | TODO: Add Link |
-| Target Release  | TODO: Add Date |
-| Product Owner   | Lucas Brown    |
-| Document Owner  | Billy Daly     |
-| Lead Developer  | Aaron Couch    |
-| Lead Designer   | Andy Cochran   |
+| Field           | Value                                                                |
+| --------------- | -------------------------------------------------------------------- |
+| Document Status | Completed                                                            |
+| Epic Link       | [Issue 49](https://github.com/HHS/grants-api/issues/49)              |
+| Epic Dashboard  | [Milestone Roadmap](https://github.com/orgs/HHS/projects/12/views/4) |
+| Target Release  | 2023-07-19                                                           |
+| Product Owner   | Lucas Brown                                                          |
+| Document Owner  | Billy Daly                                                           |
+| Lead Developer  | Aaron Couch                                                          |
+| Lead Designer   | Andy Cochran                                                         |
 
 
 ## Short description
 <!-- Required -->
 
-Formalize a series of architectural decisions about the API, including the technology stack we will use, the type of API we will build, and the services we'll leverage to deploy and host it.
+Formalize a series of architectural decisions about the front-end, including the technology stack we will use and the services we'll leverage to deploy and host it.
 
 ## Goals
 
 ### Business description & value
 <!-- Required -->
 
-{3-4 sentences that describe why this milestone is critical to the project}
+We want to select a technology stack that will maximize the long-term maintainability and performance of the front-end application that we build.
+
+The prime motivation for the decisions outlined below is to select tools that have a proven track record for front-end development, are relatively accessible to both internal and external stakeholders, and can support the future needs of the project both in terms of scale and complexity.
+
 
 ### User Stories
 <!-- Required -->
 
 - As an **HHS Staff Member**, I want:
-  - the API to be built using well-established tools and frameworks, so that it will be easier to hire future HHS staff and contractors who are familiar with the technology stack
+  - the front-end application to be built using well-established tools and frameworks, so that it will be easier to hire future HHS staff and contractors who are familiar with the technology stack
   - the deployment services we select to be FedRAMP compliant and covered under our existing ATO (where possible), so that we minimize the amount of time we need to spend seeking approval for new technology
   - to balance direct operating and hosting costs with staff resources required to maintain these tools, so that we are making intentional investments that minimize maintenance overhead without exceeding our budget
 - As a **project maintainer**, I want to:
   - select tools that satisfy both the current and future needs of the project, so that we can minimize the number of languages and frameworks we support (where possible) and don't need to reimplement existing features at a later point in the time
   - leverage hosting services that are relatively easy to maintain and scale, so that we can prioritize developing important product features over managing basic infrastructure
 - As an **open source contributor**, I want:
-  - the frontend to be built using tools that are popular with a robust open source community, so that I have a lot of resources to reference and learn from if I want to contribute to the project
-  - TODO
+  - the front-end to be built using tools that are popular with a robust open source community, so that I have a lot of resources to reference and learn from if I want to contribute to the project
 - As an **applicant**, I want:
   - the Grants.gov website to load quickly, so that I move between pages quickly and without much friction
-  - TODO
 
 ## Technical description
 
 ### Front-end Language
 
-Evaluate and select the programming language we'll use to build the API.
+Evaluate and select the programming language we'll use to build the front-end application.
 
 Some potential options include:
 
@@ -62,9 +63,9 @@ Some factors to consider are:
 - Does the selection of this language make it easier to support other parts of the project (e.g. back-end development of the API or ETL )?
 - How well does this language support important features like concurrency, type safety, and immutability?
 
-### Frontend Framework
+### Front-end Framework
 
-Evaluate and select the web framework or library we'll use to implement the API in the chosen language.
+Evaluate and select the web framework or library we'll use to implement the front-end application in the chosen language.
 
 Some potential options include:
 
@@ -80,7 +81,7 @@ Some factors to consider are:
 - Does this framework support both Static Site Generation (SSG) and Server-side Rendering (SSR)?
 - Is there an established set of plugins or libraries that extend the framework's key features? (e.g. AuthN/AuthZ, component library, etc.)
 
-### API Deployment Service
+### Front-end Deployment Service
 
 Evaluate and select an option used to deploy and host the Front-end.
 
@@ -112,10 +113,31 @@ Some factors to consider are:
 ### Proposed metrics for measuring goals/value/definition of done
 <!-- Required -->
 
-1. {Metric 1}
+#### One-time metrics
+
+We recommend calculating the following metrics at least once to inform the selection of tools for this milestone:
+
+1. Front-end language metrics
+   1. Days since last patch or minor release
+   2. Number of GitHub stars on main repository
+   3. TIOBE index ranking
+2. Front-end framework metrics
+   1. Days since last patch or minor release
+   2. Number of GitHub stars on main repository
+   3. Number of downloads from primary package manager
+
+#### Ongoing metrics
+
+The following metrics should be tracked about the tools selected within this metric: 
+
+1. Front-end framework metrics
+   1. Days since last patch or minor release
+   2. Number of GitHub stars on main repository
 
 ### Destination for live updating metrics
 <!-- Required -->
+
+Page on the public wiki. **Note:** This will likely change once we deliver [the Public Measurement Dashboard milestone](../milestone_short_descriptions.md#public-measurement-dashboards)
 
 ## Planning
 
@@ -142,7 +164,7 @@ beginning of work on this milestone?
 
 The following work will *not* be completed as part of this milestone:
 
-1. **Deploying services:** This milestone involves evaluating and selecting the tools that constitute the API technology stack, but does not involve actively setting up the code base to implement or deploying any services
+1. **Deploying services:** This milestone involves evaluating and selecting the tools that constitute the front-end technology stack, but does not involve actively setting up the code base to implement or deploying any services
 
 ## Integrations
 
@@ -160,21 +182,21 @@ The following work will *not* be completed as part of this milestone:
 
 *This can include services going into PROD behind a feature flag that is not turned on.*
 
-1. No
+1. No, this is just a planning milestone
 
 ### Services being integrated in PROD for the first time
 <!-- Required -->
 
 *Are there multiple services that are being connected for the first time in PROD?*
 
-1. No
+1. No, this is just a planning milestone
 
 ### Data being shared publicly for the first time
 <!-- Required -->
 
 *Are there any fields being shared publicly that have never been shared in PROD before?*
 
-1. No
+1. No, this is just a planning milestone
 
 ### Security considerations
 <!-- Required -->
@@ -183,4 +205,4 @@ The following work will *not* be completed as part of this milestone:
 
 *If so, how are we addressing these risks?*
 
-1. No
+1. No, this is just a planning milestone

--- a/documentation/milestones/individual_milestones/frontend_planning.md
+++ b/documentation/milestones/individual_milestones/frontend_planning.md
@@ -3,7 +3,7 @@
 | Field           | Value                                                                |
 | --------------- | -------------------------------------------------------------------- |
 | Document Status | Completed                                                            |
-| Epic Link       | [Issue 49](https://github.com/HHS/grants-api/issues/49)              |
+| Epic Link       | [Issue 49](https://github.com/HHS/grants-equity/issues/49)              |
 | Epic Dashboard  | [Milestone Roadmap](https://github.com/orgs/HHS/projects/12/views/4) |
 | Target Release  | 2023-07-19                                                           |
 | Product Owner   | Lucas Brown                                                          |

--- a/documentation/milestones/individual_milestones/frontend_planning.md
+++ b/documentation/milestones/individual_milestones/frontend_planning.md
@@ -104,7 +104,7 @@ Some factors to consider are:
 ### Definition of done
 <!-- Required -->
 
-- [ ] The tools and services chosen have been authorized under the Grants.gov ATO (Authority to Operate)
+- [ ] The tools and services chosen have been authorized under the Grants.gov ATO (Authority to Operate) and/or are FedRAMP approved
 - [ ] An ADR has been recorded and published to `main` for each of the following choices:
   - [ ] Front-end Language
   - [ ] Front-end framework

--- a/documentation/milestones/individual_milestones/frontend_planning.md
+++ b/documentation/milestones/individual_milestones/frontend_planning.md
@@ -1,0 +1,186 @@
+# Front-end Planning
+
+| Field           | Value          |
+| --------------- | -------------- |
+| Document Status | Draft          |
+| Epic Link       | TODO: Add Link |
+| Epic Dashboard  | TODO: Add Link |
+| Target Release  | TODO: Add Date |
+| Product Owner   | Lucas Brown    |
+| Document Owner  | Billy Daly     |
+| Lead Developer  | Aaron Couch    |
+| Lead Designer   | Andy Cochran   |
+
+
+## Short description
+<!-- Required -->
+
+Formalize a series of architectural decisions about the API, including the technology stack we will use, the type of API we will build, and the services we'll leverage to deploy and host it.
+
+## Goals
+
+### Business description & value
+<!-- Required -->
+
+{3-4 sentences that describe why this milestone is critical to the project}
+
+### User Stories
+<!-- Required -->
+
+- As an **HHS Staff Member**, I want:
+  - the API to be built using well-established tools and frameworks, so that it will be easier to hire future HHS staff and contractors who are familiar with the technology stack
+  - the deployment services we select to be FedRAMP compliant and covered under our existing ATO (where possible), so that we minimize the amount of time we need to spend seeking approval for new technology
+  - to balance direct operating and hosting costs with staff resources required to maintain these tools, so that we are making intentional investments that minimize maintenance overhead without exceeding our budget
+- As a **project maintainer**, I want to:
+  - select tools that satisfy both the current and future needs of the project, so that we can minimize the number of languages and frameworks we support (where possible) and don't need to reimplement existing features at a later point in the time
+  - leverage hosting services that are relatively easy to maintain and scale, so that we can prioritize developing important product features over managing basic infrastructure
+- As an **open source contributor**, I want:
+  - the frontend to be built using tools that are popular with a robust open source community, so that I have a lot of resources to reference and learn from if I want to contribute to the project
+  - TODO
+- As an **applicant**, I want:
+  - the Grants.gov website to load quickly, so that I move between pages quickly and without much friction
+  - TODO
+
+## Technical description
+
+### Front-end Language
+
+Evaluate and select the programming language we'll use to build the API.
+
+Some potential options include:
+
+- JavaScript
+- TypeScript
+- Golang
+- Others recommended by the dev team
+
+Some factors to consider are:
+
+- Is this language well established with a broad community of users?
+- How difficult is it for developers to learn the language if they haven't used it before?
+- How often is this language used for front-end development?
+- Does the selection of this language make it easier to support other parts of the project (e.g. back-end development of the API or ETL )?
+- How well does this language support important features like concurrency, type safety, and immutability?
+
+### Frontend Framework
+
+Evaluate and select the web framework or library we'll use to implement the API in the chosen language.
+
+Some potential options include:
+
+- Next.js, Vue.js, or Svelte for JavaScript/TypeScript
+- Hugo or Martini for Go
+- Others recommended by the dev team
+
+Some factors to consider are:
+
+- Is this framework popular with a broad community of users?
+- Is this framework actively maintained, with a strong governance structure?
+- How easy 
+- Does this framework support both Static Site Generation (SSG) and Server-side Rendering (SSR)?
+- Is there an established set of plugins or libraries that extend the framework's key features? (e.g. AuthN/AuthZ, component library, etc.)
+
+### API Deployment Service
+
+Evaluate and select an option used to deploy and host the Front-end.
+
+Some potential options include:
+
+- S3 buckets (for static content) and AWS Lambda (serverless functions)
+- Dedicated EC2 instance or ECS cluster
+- Vercel
+- Netlify
+- Others recommended by dev team
+
+Some factors to consider are:
+
+- Is this deployment option FedRAMP compliant?
+- How commonly used is this deployment option? Is it easy for new developers to learn?
+- How expensive is it to deploy a front-end application with this option, both in terms of direct operating costs and in terms of team resources?
+- How easily does this option scale?
+
+
+### Definition of done
+<!-- Required -->
+
+- [ ] The tools and services chosen have been authorized under the Grants.gov ATO (Authority to Operate)
+- [ ] An ADR has been recorded and published to `main` for each of the following choices:
+  - [ ] Front-end Language
+  - [ ] Front-end framework
+  - [ ] Front-end deployment service
+
+### Proposed metrics for measuring goals/value/definition of done
+<!-- Required -->
+
+1. {Metric 1}
+
+### Destination for live updating metrics
+<!-- Required -->
+
+## Planning
+
+### Assumptions & dependencies
+<!-- Optional -->
+
+What capabilities / milestones do we expect to be in place at the beginning of work
+on this milestone?
+
+- [x] **Onboard dev team:** The dev team will be evaluating and making many of these key architectural decisions
+
+Are there any notable capabilities / milestones do NOT we expect to be in place at the
+beginning of work on this milestone?
+
+- [x] None
+
+### Open questions
+<!-- Optional -->
+
+- [x] None
+
+### Not doing
+<!-- Optional -->
+
+The following work will *not* be completed as part of this milestone:
+
+1. **Deploying services:** This milestone involves evaluating and selecting the tools that constitute the API technology stack, but does not involve actively setting up the code base to implement or deploying any services
+
+## Integrations
+
+### Translations
+<!-- Required -->
+
+*Does this milestone involve delivering any content that needs translation?*
+
+*If so, when will English-language content be locked? Then when will translation be started and completed?*
+
+- No
+
+### Services going into PROD for the first time
+<!-- Required -->
+
+*This can include services going into PROD behind a feature flag that is not turned on.*
+
+1. No
+
+### Services being integrated in PROD for the first time
+<!-- Required -->
+
+*Are there multiple services that are being connected for the first time in PROD?*
+
+1. No
+
+### Data being shared publicly for the first time
+<!-- Required -->
+
+*Are there any fields being shared publicly that have never been shared in PROD before?*
+
+1. No
+
+### Security considerations
+<!-- Required -->
+
+*Does this milestone expose any new attack vectors or expand the attack surface of the product?*
+
+*If so, how are we addressing these risks?*
+
+1. No

--- a/documentation/milestones/milestone_dependency_diagram.mmd
+++ b/documentation/milestones/milestone_dependency_diagram.mmd
@@ -78,7 +78,7 @@ flowchart LR
 
     subgraph User interface
         Web-Analytics-Legacy
-        FE-Plan
+        FE-Plan::executing
         FE-Plan --> Static-Site:::northStar
         FE-CI-CD
         FE-Plan --> FE-CI-CD

--- a/documentation/milestones/milestone_short_descriptions.md
+++ b/documentation/milestones/milestone_short_descriptions.md
@@ -803,7 +803,9 @@ Diagram short name: `FE-Plan`
 
 Dependencies: `None`
 
-Choose language (e.g., TypeScript), framework (e.g., React) and testing framework (e.g., Jest) for front-end.
+Milestone doc: [Front-end planning](./individual_milestones/frontend_planning.md)
+
+Formalize a series of architectural decisions about the front-end, including the technology stack we will use and the services we'll leverage to deploy and host it.
 
 ## Front-end CI-CD
 Diagram short name: `FE-CI-CD`


### PR DESCRIPTION
### Description

Creates the Front-end Planning milestone definition.

Resolves: #32 

### Changes Proposed

- Creates `documentation/milestones/individual_milestones/frontend_planning.md`
- Updates the status of `FE-Plan` in the dependency diagram
- Links milestone definition into short description doc
- Fixes issues with published milestone docs:
  - Updates Comms Platform doc status to "Completed"
  - Updates location for publishing API Planning metrics

### TODO

- [x] Link milestone doc to short description
- [x] Update status of `FE-Plan` in dependency diagram
- [x] Finish milestone doc
  - [x] Business description & value
  - [x] User stories
  - [x] Technical description (refine)
  - [x] Definition of done
  - [x] Proposed metrics