### PR TITLE
[103] ADR: Use Figma as design prototyping tool

### DIFF
--- a/documentation/decisions/adr/000n-design-prototyping-tool.md
+++ b/documentation/decisions/adr/000n-design-prototyping-tool.md
@@ -1,6 +1,6 @@
 # Use Figma for design prototyping
 
-- **Status:** Draft <!-- REQUIRED -->
+- **Status:** Proposed <!-- REQUIRED -->
 - **Last Modified:** 2023-07-03 <!-- REQUIRED -->
 - **Related Issue:** [#103](https://github.com/HHS/grants-api/issues/103) <!-- RECOMMENDED -->
 - **Deciders:** Andy Cochran, Emily Ianacone, Lucas Brown <!-- REQUIRED -->

--- a/documentation/decisions/adr/000n-design-prototyping-tool.md
+++ b/documentation/decisions/adr/000n-design-prototyping-tool.md
@@ -1,0 +1,79 @@
+# Use Figma for design prototyping
+
+- **Status:** Draft <!-- REQUIRED -->
+- **Last Modified:** 2023-07-03 <!-- REQUIRED -->
+- **Related Issue:** [#103](https://github.com/HHS/grants-api/issues/103) <!-- RECOMMENDED -->
+- **Deciders:** Andy Cochran, Emily Ianacone, Lucas Brown <!-- REQUIRED -->
+- **Tags:** design <!-- OPTIONAL -->
+
+## Context and Problem Statement
+
+Which tool should be used for wireframing and prototyping? The tool should facilitate design conversation, be easilty integrated into research activities, and provide artifacts for stakeholder review.
+
+## Decision Drivers <!-- RECOMMENDED -->
+
+- Platform availability
+- Live collborative editing
+- assets can be integrated into design research tools
+- tool and assets must be accessible to internal partners (HHS or employed by HHS) and external partners (general public).
+- Nava familiarity
+
+## Options Considered
+
+- Figma
+- Adobe XD
+- Sketch
+- Invision Studio
+
+## Decision Outcome <!-- REQUIRED -->
+
+Chosen option: Figma, because it is not platform specific and its multi-user collaboration allows for easy remote pairing. It's assets can be easily shared, embedded, or integrated into research tools. Additionaly, Nava has the most familiarity with this option.
+
+### Positive Consequences <!-- OPTIONAL -->
+
+- Truss has developed [Figma assets using USWDS](https://www.figma.com/community/file/836611771720754351/U.S.-Web-Design-System-(USWDS))
+- Figma's free tier does not require FOSS contributors to purchase licenses
+- Figma has a robust community of plugins and integrations
+- Includes Figjam (tho this may be redundant, depending on chosen whiteboarding tool)
+
+### Negative Consequences <!-- OPTIONAL -->
+
+- Collaborative nature of Figma requires connectivity and working online
+- Tho version control and file management is possible, it can be difficult to track _who_ made recent changes
+
+## Pros and Cons of the Options <!-- OPTIONAL -->
+
+### Figma
+
+- **Pro**
+  - Browser-based (works on Mac, Windows, Linux…)
+  - Free forever
+  - Nava familiarity
+  - Robust plugin community
+- **Cons**
+  - Limited files (3) in free tier
+  - Requires internet connectivity
+
+### Adobe XD
+
+- **Pro**
+  - Part of Adobe Creative Suite
+- **Cons**
+  - Native app, not browser-based
+  - No free tier (7-day trial)
+
+### Sketch
+
+- **Pro**
+  - Lowest subscription cost
+- **Cons**
+  - Mac only (nonstarter?)
+  - No free tier (30-day trial)
+
+### Invision Studio
+
+- Nonstarter: [tool is being sunset](https://help.invisionapp.com/hc/en-us/community/posts/11525657213965-SUNSET-NOTIFICATION-Studio)
+
+## Links <!-- OPTIONAL -->
+
+- [Figma pricing](https://www.figma.com/pricing/)


### PR DESCRIPTION
Resolves #103 

This ADR recommends the use of Figma for design prototyping. 