### PR TITLE
[ISSUE 321] Standardize Github Action workflow naming conventions

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -22,6 +22,7 @@ jobs:
     # if we built the docker image and shared
     # it across jobs as described in:
     # https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow
+    name: API Lint & Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -22,7 +22,7 @@ jobs:
     # if we built the docker image and shared
     # it across jobs as described in:
     # https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow
-    name: API Lint & Tests
+    name: API Lint, Format & Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -6,11 +6,11 @@ on:
       - main
     paths:
       - api/**
-      - .github/workflows/api-checks.yml
+      - .github/workflows/ci-api.yml
   pull_request:
     paths:
       - api/**
-      - .github/workflows/api-checks.yml
+      - .github/workflows/ci-api.yml
 
 defaults:
   run:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,4 +1,4 @@
-name: CI - Front End
+name: Front-end Checks
 
 on:
   push:
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   tests:
-    name: Tests
+    name: Front-end Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +38,7 @@ jobs:
       - run: npm run test
 
   lint:
-    name: Lint
+    name: Front-end Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -52,7 +52,7 @@ jobs:
       - run: npm run lint
 
   types:
-    name: Type check
+    name: Front-end Type Check
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +66,7 @@ jobs:
       - run: npm run ts:check
 
   formatting:
-    name: Format check
+    name: Front-end Format Check
     runs-on: ubuntu-latest
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   # Confirms the front end still builds successfully
   check-frontend-builds:
-    name: Build check - Front End
+    name: Front-end Build Check
     runs-on: ubuntu-latest
 
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   # Confirms Storybook still builds successfully
   check-storybook-builds:
-    name: Build check - Storybook
+    name: Front-end Storybook Build Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   tests:
-    name: Front-end Tests
+    name: FE Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +38,7 @@ jobs:
       - run: npm run test
 
   lint:
-    name: Front-end Lint
+    name: FE Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -52,7 +52,7 @@ jobs:
       - run: npm run lint
 
   types:
-    name: Front-end Type Check
+    name: FE Type Check
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +66,7 @@ jobs:
       - run: npm run ts:check
 
   formatting:
-    name: Front-end Format Check
+    name: FE Format Check
     runs-on: ubuntu-latest
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   # Confirms the front end still builds successfully
   check-frontend-builds:
-    name: Front-end Build Check
+    name: FE Build Check
     runs-on: ubuntu-latest
 
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   # Confirms Storybook still builds successfully
   check-storybook-builds:
-    name: Front-end Storybook Build Check
+    name: FE Storybook Build Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   tests:
-    name: FE Tests
+    name: FE Lint, Type Check, Format & Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -35,49 +35,18 @@ jobs:
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
           cache: ${{ env.PACKAGE_MANAGER }}
       - run: npm ci
-      - run: npm run test
 
-  lint:
-    name: FE Lint
-    runs-on: ubuntu-latest
+      - name: Run lint
+        run: npm run lint
 
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
-          cache: ${{ env.PACKAGE_MANAGER }}
-      - run: npm ci
-      - run: npm run lint
+      - name: Run type check
+        run: npm run ts:check
 
-  types:
-    name: FE Type Check
-    runs-on: ubuntu-latest
+      - name: Run format
+        run: npm run format-check
 
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
-          cache: ${{ env.PACKAGE_MANAGER }}
-      - run: npm ci
-      - run: npm run ts:check
-
-  formatting:
-    name: FE Format Check
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
-          cache: ${{ env.PACKAGE_MANAGER }}
-      - run: npm ci
-      - run: npm run format-check
+      - name: Run tests
+        run: npm run test
 
   # Confirms the front end still builds successfully
   check-frontend-builds:

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   update-openapi-docs:
+    name: Update OpenAPI Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -22,7 +22,6 @@ concurrency:
 
 jobs:
   update-openapi-docs:
-    name: Update OpenAPI Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
Fixes #321 

### Time to review: __3 mins__

## Changes proposed
Update naming of GA workflows that will be used in PR checks to be clearer.

- Smash front-end checks for linting, testing, format checking and type checking together. They were separate and doing separate `npm ci` installs for each. Extra time + making PR checks look quite cluttered. If you want to see a specific, you can click on "details" and then expand the section that you're interested in, same as when they were separated.
- Update path naming for API workflow because it was wrong and not getting run.
- Leave FE & API in naming convention for sub-categories of workflows. The reasoning is that when setting up branch protection rules, it makes it easier to find the check you're looking for since you search by sub-category. It does look a bit redundant on PRs, but doesn't bother me, personally. Thoughts? The Github UI here is less than ideal.
<img width="746" alt="Screenshot 2023-07-24 at 12 24 48 PM" src="https://github.com/HHS/grants-equity/assets/13158571/b80f6a71-11c7-44c1-9e1f-d02ecf99c646">
