### PR TITLE
[Issue 397] SEO title and description

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,8 +1,7 @@
 {
   "Index": {
-    "title": "Home",
-    "intro": "This is a template for a React web application using the <LinkToNextJs>Next.js framework</LinkToNextJs>.",
-    "body": "This is template includes:<ul><li>Framework for server-side rendered, static, or hybrid React applications</li><li>TypeScript and React testing tools</li><li>U.S. Web Design System for themeable styling and a set of common components</li><li>Type checking, linting, and code formatting tools</li><li>Storybook for a frontend workshop environment</li></ul>",
+    "page_title": "Home | Beta.grants.gov",
+    "meta_description": "The beta version of a government website where federal agencies post discretionary funding opportunities and grantees find and apply for them",
     "alert": "This website is a work in progress. To search for funding opportunities and apply, visit <LinkToGrants>www.grants.gov</LinkToGrants>.",
     "goal_title": "What's the goal?",
     "goal_paragraph_1": "We want Grants.gov to be the simplest, most inclusive, and most gratifying tool ever built for posting, finding, sharing, and applying for financial assistance. Our mission is to increase access to grants and improve the grants experience for everyone.",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,7 +1,7 @@
 {
   "Index": {
     "page_title": "Home | Beta.grants.gov",
-    "meta_description": "The beta version of a government website where federal agencies post discretionary funding opportunities and grantees find and apply for them",
+    "meta_description": "Our mission is to increase access to grants and improve the grants experience for everyone. A one-stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     "alert": "This website is a work in progress. To search for funding opportunities and apply, visit <LinkToGrants>www.grants.gov</LinkToGrants>.",
     "goal_title": "What's the goal?",
     "goal_paragraph_1": "We want Grants.gov to be the simplest, most inclusive, and most gratifying tool ever built for posting, finding, sharing, and applying for financial assistance. Our mission is to increase access to grants and improve the grants experience for everyone.",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,7 +1,7 @@
 {
   "Index": {
     "page_title": "Home | Beta.grants.gov",
-    "meta_description": "Our mission is to increase access to grants and improve the grants experience for everyone. A one-stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
+    "meta_description": "A one-stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     "alert": "This website is a work in progress. To search for funding opportunities and apply, visit <LinkToGrants>www.grants.gov</LinkToGrants>.",
     "goal_title": "What's the goal?",
     "goal_paragraph_1": "We want Grants.gov to be the simplest, most inclusive, and most gratifying tool ever built for posting, finding, sharing, and applying for financial assistance. Our mission is to increase access to grants and improve the grants experience for everyone.",

--- a/frontend/src/components/PageSEO.tsx
+++ b/frontend/src/components/PageSEO.tsx
@@ -10,7 +10,12 @@ const PageSEO = ({ title, description }: Props) => {
     <Head>
       <title>{title}</title>
       <meta property="og:title" content={title} key="title" />
-      <meta name="description" content={description} key="description" />
+      <meta
+        data-testid="meta-description"
+        name="description"
+        content={description}
+        key="description"
+      />
     </Head>
   );
 };

--- a/frontend/src/components/PageSEO.tsx
+++ b/frontend/src/components/PageSEO.tsx
@@ -3,15 +3,14 @@ import Head from "next/head";
 type Props = {
   title: string;
   description: string;
-  titleKey: string;
 };
 
-const PageSEO = ({ title, description, titleKey }: Props) => {
+const PageSEO = ({ title, description }: Props) => {
   return (
     <Head>
       <title>{title}</title>
-      <meta property="og:title" content={title} key={titleKey} />
-      <meta name="description" content={description} />
+      <meta property="og:title" content={title} key="title" />
+      <meta name="description" content={description} key="description" />
     </Head>
   );
 };

--- a/frontend/src/components/PageSEO.tsx
+++ b/frontend/src/components/PageSEO.tsx
@@ -1,0 +1,19 @@
+import Head from "next/head";
+
+type Props = {
+  title: string;
+  description: string;
+  titleKey: string;
+};
+
+const PageSEO = ({ title, description, titleKey }: Props) => {
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta property="og:title" content={title} key={titleKey} />
+      <meta name="description" content={description} />
+    </Head>
+  );
+};
+
+export default PageSEO;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -3,8 +3,8 @@ import { ExternalRoutes } from "src/constants/routes";
 
 import { Trans, useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import Head from "next/head";
 
+import PageSEO from "src/components/PageSEO";
 import WtGIContent from "src/components/WtGIContent";
 import FullWidthAlert from "../components/FullWidthAlert";
 import FundingContent from "../components/FundingContent";
@@ -16,10 +16,7 @@ const Home: NextPage = () => {
 
   return (
     <>
-      <Head>
-        <title>{t("page_title")}</title>
-        <meta name="description" content={t("meta_description")} key="Index" />
-      </Head>
+      <PageSEO title={t("page_title")} description={t("meta_description")} />
       <Hero />
       <FullWidthAlert type="info">
         <Trans

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -9,12 +9,17 @@ import FullWidthAlert from "../components/FullWidthAlert";
 import FundingContent from "../components/FundingContent";
 import GoalContent from "../components/GoalContent";
 import Hero from "../components/Hero";
+import Head from "next/head";
 
 const Home: NextPage = () => {
   const { t } = useTranslation("common", { keyPrefix: "Index" });
 
   return (
     <>
+      <Head>
+        <title>{t("page_title")}</title>
+        <meta name="description" content={t("meta_description")} key="Index"/>
+      </Head>
       <Hero />
       <FullWidthAlert type="info">
         <Trans

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -3,13 +3,13 @@ import { ExternalRoutes } from "src/constants/routes";
 
 import { Trans, useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import Head from "next/head";
 
 import WtGIContent from "src/components/WtGIContent";
 import FullWidthAlert from "../components/FullWidthAlert";
 import FundingContent from "../components/FundingContent";
 import GoalContent from "../components/GoalContent";
 import Hero from "../components/Hero";
-import Head from "next/head";
 
 const Home: NextPage = () => {
   const { t } = useTranslation("common", { keyPrefix: "Index" });
@@ -18,7 +18,7 @@ const Home: NextPage = () => {
     <>
       <Head>
         <title>{t("page_title")}</title>
-        <meta name="description" content={t("meta_description")} key="Index"/>
+        <meta name="description" content={t("meta_description")} key="Index" />
       </Head>
       <Hero />
       <FullWidthAlert type="info">

--- a/frontend/tests/components/PageSEO.test.tsx
+++ b/frontend/tests/components/PageSEO.test.tsx
@@ -27,7 +27,7 @@ describe("PageSEO", () => {
     expect(description.content).toBe("test description");
   });
 
-  it("Renders the correct title after rerendering", async () => {
+  it("Renders the correct title after rerendering", () => {
     const initialProps = {
       title: "test title",
       description: "test description",

--- a/frontend/tests/components/PageSEO.test.tsx
+++ b/frontend/tests/components/PageSEO.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import PageSEO from "src/components/PageSEO";
+
+jest.mock("next/head", () => {
+  return {
+    __esModule: true,
+    default: ({ children }: { children: Array<React.ReactElement> }) => {
+      return <>{children}</>;
+    },
+  };
+});
+
+describe("PageSEO", () => {
+  it("Renders title without errors", () => {
+    const props = { title: "test title", description: "test description" };
+    render(<PageSEO {...props} />);
+    expect(document.title).toBe("test title");
+  });
+
+  it("Renders meta description content without errors", () => {
+    const props = { title: "test title", description: "test description" };
+    render(<PageSEO {...props} />);
+    const description = document.querySelector(
+      "meta[name='description']"
+    ) as HTMLTemplateElement;
+    expect(description.content).toBe("test description");
+  });
+
+  it("Renders the correct title after rerendering", async () => {
+    const initialProps = {
+      title: "test title",
+      description: "test description",
+    };
+    const updatedProps = {
+      title: "updated test title",
+      description: "updated test description",
+    };
+    const { rerender } = render(<PageSEO {...initialProps} />);
+    expect(document.title).toBe("test title");
+    rerender(<PageSEO {...updatedProps} />);
+    expect(document.title).toBe("updated test title");
+  });
+});

--- a/frontend/tests/components/PageSEO.test.tsx
+++ b/frontend/tests/components/PageSEO.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import PageSEO from "src/components/PageSEO";
 
@@ -15,16 +15,15 @@ describe("PageSEO", () => {
   it("Renders title without errors", () => {
     const props = { title: "test title", description: "test description" };
     render(<PageSEO {...props} />);
-    expect(document.title).toBe("test title");
+    const title = screen.getByText("test title");
+    expect(title).toBeInTheDocument();
   });
 
   it("Renders meta description content without errors", () => {
     const props = { title: "test title", description: "test description" };
     render(<PageSEO {...props} />);
-    const description = document.querySelector(
-      "meta[name='description']"
-    ) as HTMLTemplateElement;
-    expect(description.content).toBe("test description");
+    const description = screen.getByTestId("meta-description");
+    expect(description).toBeInTheDocument();
   });
 
   it("Renders the correct title after rerendering", () => {
@@ -37,8 +36,12 @@ describe("PageSEO", () => {
       description: "updated test description",
     };
     const { rerender } = render(<PageSEO {...initialProps} />);
-    expect(document.title).toBe("test title");
+    const title = screen.getByText("test title");
+    expect(title).toBeInTheDocument();
     rerender(<PageSEO {...updatedProps} />);
-    expect(document.title).toBe("updated test title");
+    const oldTitle = screen.queryByText("test title");
+    const updatedtitle = screen.getByText("updated test title");
+    expect(oldTitle).not.toBeInTheDocument();
+    expect(updatedtitle).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/PageSEO.test.tsx
+++ b/frontend/tests/components/PageSEO.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 import PageSEO from "src/components/PageSEO";
 


### PR DESCRIPTION
## Summary
Fixes #397 

### Time to review: 5 minutes

## Changes proposed

- Added Head to index page with title and meta description
- Added content for title and meta description to i18n

## Context for reviewers
I took a guess at the content, so that'd be the most important piece to review. But changing/updating that in the future would be a 1 point ticket, so it's really not a big deal to update.

## Additional information
### Title in tab
![image](https://github.com/HHS/grants-equity/assets/25465464/38968ec4-c1d5-4eae-a818-3bcb379917d3)

### Google lighthouse score
![image](https://github.com/HHS/grants-equity/assets/25465464/931ba7af-c81b-4cfc-9824-d1e54a8a34d6)

