### PR TITLE
[Issue #440] add github CTA to Hero

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -36,7 +36,8 @@
   "Hero": {
     "title": "We're building a new Grants.gov!",
     "beta": "BETA!",
-    "content": "This new website will be your go‑to resource to follow our progress on improving funding opportunity announcements and the application experience."
+    "content": "This new website will be your go‑to resource to follow our progress on improving funding opportunity announcements and the application experience.",
+    "github_link": "Follow on GitHub"
   },
   "Footer": {
     "agency_name": "Agency name",

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -26,6 +26,7 @@ const Hero = () => {
         >
           <Icon.Github
             className="usa-icon usa-icon--size-3 margin-right-1 text-middle tablet:margin-top-neg-2px"
+            size={3}
             aria-label="Github"
           />
           {t("github_link")}

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -24,7 +24,10 @@ const Hero = () => {
           href={ExternalRoutes.GITHUB_REPO}
           target="_blank"
         >
-          <Icon.Github className="usa-icon usa-icon--size-3 margin-right-1 text-middle tablet:margin-top-neg-2px" />
+          <Icon.Github
+            className="usa-icon usa-icon--size-3 margin-right-1 text-middle tablet:margin-top-neg-2px"
+            aria-label="Github"
+          />
           {t("github_link")}
         </Link>
       </GridContainer>

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,5 +1,8 @@
+import { ExternalRoutes } from "src/constants/routes";
+
 import { useTranslation } from "next-i18next";
-import { GridContainer } from "@trussworks/react-uswds";
+import Link from "next/link";
+import { GridContainer, Icon } from "@trussworks/react-uswds";
 
 const Hero = () => {
   const { t } = useTranslation("common", {
@@ -8,7 +11,7 @@ const Hero = () => {
 
   return (
     <div data-testid="hero" className="usa-dark-background bg-primary">
-      <GridContainer className="padding-y-1 tablet:padding-y-3 tablet-lg:padding-y-10 desktop-lg:padding-y-15">
+      <GridContainer className="padding-y-1 tablet:padding-y-3 tablet-lg:padding-y-10 desktop-lg:padding-y-15 position-relative">
         <h1 className="tablet:font-sans-2xl desktop-lg:font-sans-3xl text-ls-neg-2">
           <span>{t("title")}</span>
         </h1>
@@ -16,6 +19,14 @@ const Hero = () => {
           <span className="text-yellow text-bold">{t("beta")}</span>&nbsp;
           {t("content")}
         </p>
+        <Link
+          className="usa-button usa-button--outline usa-button--inverse font-sans-2xs tablet:font-sans-md margin-bottom-3 desktop:position-absolute top-3 right-0 desktop:margin-y-3 desktop:margin-x-4"
+          href={ExternalRoutes.GITHUB_REPO}
+          target="_blank"
+        >
+          <Icon.Github className="usa-icon usa-icon--size-3 margin-right-1 text-middle tablet:margin-top-neg-2px" />
+          {t("github_link")}
+        </Link>
       </GridContainer>
     </div>
   );

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -39,6 +39,14 @@ in the form $setting: value,
   $theme-column-gap-desktop: 6,
   $theme-column-gap-md: 4,
   $theme-column-gap-lg: 6,
+  $position-settings: (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false
+  ),
 
   // Typography settings
   $theme-global-link-styles: true,


### PR DESCRIPTION
## Summary
Fixes #440

### Time to review: __1 mins__

## Changes proposed
- Add a button linking to this GitHub repo in the Hero component. 

## Context for reviewers
per Lucas's request to make this call-to-action more prominent

## Additional information

![image](https://github.com/HHS/grants-equity/assets/409279/da442d17-a6c5-44a5-928d-28ee3a90d2de)
