### PR TITLE
[ISSUE 487] Fix caching and build command

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -8,10 +8,10 @@ on:
       - infra/**
       - .github/workflows/ci-infra.yml
   pull_request:
-    paths:
-      - infra/**
-      - test/**
-      - .github/workflows/ci-infra.yml
+    # paths:
+    #   - infra/**
+    #   - test/**
+    #   - .github/workflows/ci-infra.yml
 
 env:
   APP_NAME: frontend

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -8,10 +8,10 @@ on:
       - infra/**
       - .github/workflows/ci-infra.yml
   pull_request:
-    # paths:
-    #   - infra/**
-    #   - test/**
-    #   - .github/workflows/ci-infra.yml
+    paths:
+      - infra/**
+      - test/**
+      - .github/workflows/ci-infra.yml
 
 env:
   APP_NAME: frontend

--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -3,6 +3,8 @@
 
 name: CI Vulnerability Scans
 
+# test comment
+
 on:
   push:
     branches:

--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -3,8 +3,6 @@
 
 name: CI Vulnerability Scans
 
-# test comment
-
 on:
   push:
     branches:

--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -83,7 +83,11 @@ jobs:
         # If there's an exact match in cache, skip build entirely
         if: steps.cache-buildx.outputs.cache-hit != 'true'
         run: |
-          make APP_NAME=${{ env.APP_NAME }} release-build
+          make release-build \
+          APP_NAME=${{ env.APP_NAME }} \
+          OPTIONAL_BUILD_FLAGS=" \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          --cache-to=type=local,dest=/tmp/.buildx-cache"
 
       - name: Save Docker image
         if: steps.cache-buildx.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -54,6 +54,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+
       - name: Cache Docker layers
         id: cache-buildx
         uses: actions/cache@v3

--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -54,9 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
-
       - name: Cache Docker layers
         id: cache-buildx
         uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ INFO_TAG := $(DATE).$(USER)
 release-build: ## Build release for $APP_NAME and tag it with current git hash
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	cd $(APP_NAME) && $(MAKE) release-build \
-		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG)"
+		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG) $(OPTIONAL_BUILD_FLAGS)"
 
 release-publish: ## Publish release to $APP_NAME's build repository
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ INFO_TAG := $(DATE).$(USER)
 release-build: ## Build release for $APP_NAME and tag it with current git hash
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	cd $(APP_NAME) && $(MAKE) release-build \
-		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG) $(OPTIONAL_BUILD_FLAGS)"
+		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG) --load -t $(IMAGE_NAME):$(IMAGE_TAG) $(OPTIONAL_BUILD_FLAGS)"
 
 release-publish: ## Publish release to $APP_NAME's build repository
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ INFO_TAG := $(DATE).$(USER)
 release-build: ## Build release for $APP_NAME and tag it with current git hash
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	cd $(APP_NAME) && $(MAKE) release-build \
-		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG) --load -t $(IMAGE_NAME):$(IMAGE_TAG)"
+		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG)"
 
 release-publish: ## Publish release to $APP_NAME's build repository
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -28,8 +28,6 @@ export RUN_UID
 release-build:
 	docker buildx build \
 	  --target release \
-		--cache-from=type=local,src=/tmp/.buildx-cache \
-		--cache-to=type=local,dest=/tmp/.buildx-cache \
 		--platform=linux/amd64 \
 		--build-arg RUN_USER=$(RUN_USER) \
 		--build-arg RUN_UID=$(RUN_UID) \


### PR DESCRIPTION
## Summary
Fixes #487

### Time to review: __5 mins__

## Changes proposed
- Pass the `--cache-to` and `--cache-from` commands exclusively for GA builds. They require a different Docker driver that is set up in GA with `setup-buildx-action` but really not necessary locally. Now `make build-release` is fixed locally and for deploys again, until deploys leverage caching as well.

## Context for reviewers
Out of curiosity, spent what felt like forever trying to leverage how Docker caching works locally against already-built images without having to cache the Docker layers explicitly. Meaning in GA we would only have to cache the .tar then load it for Docker daemon and then build then voila. But I *cannot* get it to work. Something is invalidating the cache, and I have reached max futzing capacity with no more ideas. Reverted back to caching layers and made it so it doesn't break our deploy command or local `make release-build` commands where caching is unnecessary. That was the true fix for this PR anyway.

Test make command locally if you like: `make release-build APP_NAME=frontend`

## Additional information
Passing deploy: https://github.com/HHS/grants-equity/actions/runs/6103883650
Passing infra checks: https://github.com/HHS/grants-equity/actions/runs/6104013359/job/16565385962?pr=488
