### PR TITLE
[ISSUE #506] Remove NOFO content

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "Index": {
-    "page_title": "Home | Beta.grants.gov",
+    "page_title": "beta.grants.gov",
     "meta_description": "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     "alert_title": "Beta.grants.gov is a work in progress.",
     "alert": "To search for funding opportunities and apply, go to <LinkToGrants>www.grants.gov</LinkToGrants>.",
@@ -33,7 +33,7 @@
     "nav_link_home": "Home",
     "nav_link_health": "Health",
     "nav_menu_toggle": "Menu",
-    "title": "Grants.gov"
+    "title": "beta.grants.gov"
   },
   "Hero": {
     "title": "We're building a new Grants.gov!",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -2,14 +2,14 @@
   "Index": {
     "page_title": "Home | Beta.grants.gov",
     "meta_description": "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
-    "alert_title": "This website is a work in progress.",
-    "alert": "To search for funding opportunities and apply, visit <LinkToGrants>www.grants.gov</LinkToGrants>.",
+    "alert_title": "Beta.grants.gov is a work in progress.",
+    "alert": "To search for funding opportunities and apply, go to <LinkToGrants>www.grants.gov</LinkToGrants>.",
     "goal_title": "What's the goal?",
     "goal_paragraph_1": "We want Grants.gov to be the simplest, most inclusive, and most gratifying tool ever built for posting, finding, sharing, and applying for financial assistance. Our mission is to increase access to grants and improve the grants experience for everyone.",
     "goal_title_2": "For applicants",
-    "goal_paragraph_2": "We’re building a one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
+    "goal_paragraph_2": "We’re building a one‑stop shop for all federal discretionary funding that makes it easy for you to discover, understand, and apply for opportunities.",
     "goal_title_3": "For grantmakers",
-    "goal_paragraph_3": "If you work for a federal grantmaking agency, we’re making it easier for you to write, post, announce, and manage funding opportunities that reach your communities, including underserved communities.",
+    "goal_paragraph_3": "If you work for a federal grantmaking agency, we’re making it easier for your communities (including underserved communities) to find the funding they need.",
     "fo_title": "Improvements to funding opportunity announcements",
     "fo_paragraph_1": "Funding opportunities should not only be easy to find, share, and apply for. They should also be easy to read and understand. Our objective is to simplify and organize funding opportunities announcements. ",
     "fo_paragraph_2": "We want to help grantmakers write clear, concise announcements that encourage strong submissions from qualified applicants and make opportunities more accessible to everyone.",
@@ -25,7 +25,7 @@
     "fo_paragraph_5": "We're especially interested in hearing from first‑time applicants and organizations that have never applied for funding opportunities. We encourage you to review our announcements and share your feedback, regardless of your experience with federal grants.",
     "wtgi_title": "Ways to get involved",
     "wtgi_paragraph_1": "Follow our progress as we improve grant announcements and build a better API and opportunity search on beta.grants.gov.",
-    "wtgi_list": "<ul><li><LinkToGoals>Read our project goals and milestones</LinkToGoals></li><li>Join our open‑source community on <github>GitHub</github></li><li>Contact us at <email>tbd@tbd.gov</email></li></ul>"
+    "wtgi_list": "<ul><li><LinkToGoals>Read our project goals and milestones</LinkToGoals></li><li>Join our open‑source community on <github>GitHub</github></li><li>Contact us at <email>{{email}}</email></li></ul>"
   },
   "Header": {
     "nav_link_home": "Home",
@@ -36,14 +36,13 @@
   "Hero": {
     "title": "We're building a new Grants.gov!",
     "beta": "BETA!",
-    "content": "This new website will be your go‑to resource to follow our progress on improving funding opportunity announcements and the application experience.",
+    "content": "This new website will be your go‑to resource to follow our progress as we improve the grants experience, making it easier to find, share, and apply.",
     "github_link": "Follow on GitHub"
   },
   "Footer": {
     "agency_name": "Grants.gov",
     "agency_contact_center": "Grants.gov Program Management Office",
     "telephone": "1-877-696-6775",
-    "email": "support@grants.gov",
     "return_to_top": "Return to top",
     "link_twitter": "Twitter",
     "link_youtube": "YouTube",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -25,7 +25,9 @@
     "fo_paragraph_5": "We're especially interested in hearing from first‑time applicants and organizations that have never applied for funding opportunities. We encourage you to review our announcements and share your feedback, regardless of your experience with federal grants.",
     "wtgi_title": "Ways to get involved",
     "wtgi_paragraph_1": "Follow our progress as we improve grant announcements and build a better API and opportunity search on beta.grants.gov.",
-    "wtgi_list": "<ul><li><LinkToGoals>Read our project goals and milestones</LinkToGoals></li><li>Join our open‑source community on <github>GitHub</github></li><li>Contact us at <email>{{email}}</email></li></ul>"
+    "wtgi_title_2": "Join our open‑source community on <github>GitHub</github>",
+    "wtgi_list": "<ul><li>Follow <repo>the repository <small>(github.com/HHS/grants-equity)</small></repo></li><li>Read the <goals>project goals</goals></li><li>View the <roadmap>Grants Equity Milestone Roadmap</roadmap></li><li>Learn about <contribute>how you can contribute</contribute></li></ul>",
+    "wtgi_paragraph_2": "<strong>Questions?</strong> Contact us at <email>{{email}}</email>."
   },
   "Header": {
     "nav_link_home": "Home",

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -76,7 +76,7 @@ const Footer = () => {
       data-testid="footer"
       size="medium"
       returnToTop={
-        <GridContainer className="usa-footer__return-to-top">
+        <GridContainer className="usa-footer__return-to-top margin-top-5">
           <a href="#">{t("return_to_top")}</a>
         </GridContainer>
       }
@@ -105,8 +105,8 @@ const Footer = () => {
                 <a key="telephone" href={`tel:${t("telephone")}`}>
                   {t("telephone")}
                 </a>,
-                <a key="email" href={ExternalRoutes.CONTACT_EMAIL}>
-                  {t("email")}
+                <a key="email" href={`mailto:${ExternalRoutes.EMAIL_SUPPORT}`}>
+                  {ExternalRoutes.EMAIL_SUPPORT}
                 </a>,
               ]}
             />

--- a/frontend/src/components/GoalContent.tsx
+++ b/frontend/src/components/GoalContent.tsx
@@ -5,7 +5,7 @@ const GoalContent = () => {
   const { t } = useTranslation("common", { keyPrefix: "Index" });
 
   return (
-    <GridContainer className="padding-y-1 tablet:padding-y-3 desktop-lg:padding-y-6">
+    <GridContainer className="padding-y-1 tablet:padding-y-3 desktop-lg:padding-y-6 border-bottom-2px border-base-lightest">
       <h2 className="margin-bottom-0 tablet-lg:font-sans-xl desktop-lg:font-sans-2xl">
         {t("goal_title")}
       </h2>

--- a/frontend/src/components/WtGIContent.tsx
+++ b/frontend/src/components/WtGIContent.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "next-i18next";
 import { Grid, GridContainer } from "@trussworks/react-uswds";
 
 const WtGIContent = () => {
+  const email = ExternalRoutes.EMAIL_EQUITYINGRANTS;
   const { t } = useTranslation("common", { keyPrefix: "Index" });
 
   return (
@@ -22,6 +23,7 @@ const WtGIContent = () => {
           <Trans
             t={t}
             i18nKey="wtgi_list"
+            values={{ email }}
             components={{
               ul: (
                 <ul className="usa-list margin-top-0 tablet-lg:margin-top-3 font-sans-md line-height-sans-4" />
@@ -41,7 +43,7 @@ const WtGIContent = () => {
                   href={ExternalRoutes.GITHUB_REPO}
                 />
               ),
-              email: <a href={ExternalRoutes.CONTACT_EMAIL} />,
+              email: <a href={`mailto:${email}`} />,
             }}
           />
         </Grid>

--- a/frontend/src/components/WtGIContent.tsx
+++ b/frontend/src/components/WtGIContent.tsx
@@ -1,7 +1,7 @@
 import { ExternalRoutes } from "src/constants/routes";
 
 import { Trans, useTranslation } from "next-i18next";
-import { Grid, GridContainer } from "@trussworks/react-uswds";
+import { Grid, GridContainer, Icon } from "@trussworks/react-uswds";
 
 const WtGIContent = () => {
   const email = ExternalRoutes.EMAIL_EQUITYINGRANTS;
@@ -20,32 +20,67 @@ const WtGIContent = () => {
           <p className="usa-intro">{t("wtgi_paragraph_1")}</p>
         </Grid>
         <Grid tabletLg={{ col: 6 }}>
+          <h3 className="margin-bottom-0-- desktop-lg:font-sans-lg">
+            <strong>
+              Join our open‑source community on{" "}
+              <span className="text-no-wrap">
+                GitHub <Icon.Github size={3} aria-label="Github" />
+              </span>
+            </strong>
+          </h3>
           <Trans
             t={t}
             i18nKey="wtgi_list"
-            values={{ email }}
             components={{
               ul: (
                 <ul className="usa-list margin-top-0 tablet-lg:margin-top-3 font-sans-md line-height-sans-4" />
               ),
               li: <li />,
-              LinkToGoals: (
+              small: <small />,
+              repo: (
                 <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={ExternalRoutes.MILESTONES}
-                />
-              ),
-              github: (
-                <a
+                  className="usa-link--external"
                   target="_blank"
                   rel="noopener noreferrer"
                   href={ExternalRoutes.GITHUB_REPO}
                 />
               ),
-              email: <a href={`mailto:${email}`} />,
+              goals: (
+                <a
+                  className="usa-link--external"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={ExternalRoutes.GITHUB_REPO_GOALS}
+                />
+              ),
+              roadmap: (
+                <a
+                  className="usa-link--external"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={ExternalRoutes.GITHUB_REPO_ROADMAP}
+                />
+              ),
+              contribute: (
+                <a
+                  className="usa-link--external"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={ExternalRoutes.GITHUB_REPO_CONTRIBUTING}
+                />
+              ),
             }}
           />
+          <p className="margin-top-3 font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
+            <Trans
+              t={t}
+              i18nKey="wtgi_paragraph_2"
+              values={{ email }}
+              components={{
+                email: <a href={`mailto:${email}`} />,
+              }}
+            />
+          </p>
         </Grid>
       </Grid>
     </GridContainer>

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -2,22 +2,23 @@ export const ExternalRoutes = {
   ABOUT_HHS: "https://www.hhs.gov/about/index.html",
   ACCESSIBILITY_COMPLIANCE:
     "https://www.grants.gov/web/grants/accessibility-compliance.html",
+  EMAIL_EQUITYINGRANTS: "equityingrants@hhs.gov",
+  EMAIL_SUPPORT: "support@grants.gov",
   FOIA: "https://www.hhs.gov/foia/index.html",
-  NO_FEAR: "https://www.hhs.gov/about/agencies/asa/eeo/no-fear-act/index.html",
+  GITHUB_REPO: "https://github.com/HHS/grants-equity",
+  GRANTS_HOME: "https://www.grants.gov",
+  GRANTS_NEWSLETTER:
+    "https://www.grants.gov/web/grants/connect/newsletter-archive.html",
+  GRANTS_RSS: "https://www.grants.gov/web/grants/rss.html",
+  GRANTS_TWITTER: "https://twitter.com/grantsdotgov",
+  GRANTS_YOUTUBE: "https://www.youtube.com/user/GrantsGovUS",
+  GRANTS_BLOG: "https://grantsgovprod.wordpress.com/",
+  HHS: "https://www.hhs.gov",
   INSPECTOR_GENERAL: "https://oig.hhs.gov/",
+  MILESTONES:
+    "https://github.com/HHS/grants-equity/blob/main/documentation/milestones/milestone_short_descriptions.md",
+  NO_FEAR: "https://www.hhs.gov/about/agencies/asa/eeo/no-fear-act/index.html",
   PERFORMANCE_REPORTS: "https://www.hhs.gov/about/budget/index.html",
   PRIVACY_POLICY: "https://www.grants.gov/web/grants/privacy.html",
   USA: "https://www.usa.gov",
-  HHS: "https://www.hhs.gov",
-  MILESTONES:
-    "https://github.com/HHS/grants-equity/blob/main/documentation/milestones/milestone_short_descriptions.md",
-  GITHUB_REPO: "https://github.com/HHS/grants-equity",
-  CONTACT_EMAIL: "mailto:support@grants.gov",
-  GRANTS_HOME: "https://www.grants.gov",
-  GRANTS_TWITTER: "https://twitter.com/grantsdotgov",
-  GRANTS_YOUTUBE: "https://www.youtube.com/user/GrantsGovUS",
-  GRANTS_RSS: "https://www.grants.gov/web/grants/rss.html",
-  GRANTS_NEWSLETTER:
-    "https://www.grants.gov/web/grants/connect/newsletter-archive.html",
-  GRANTS_BLOG: "https://grantsgovprod.wordpress.com/",
 };

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -6,6 +6,11 @@ export const ExternalRoutes = {
   EMAIL_SUPPORT: "support@grants.gov",
   FOIA: "https://www.hhs.gov/foia/index.html",
   GITHUB_REPO: "https://github.com/HHS/grants-equity",
+  GITHUB_REPO_CONTRIBUTING:
+    "https://github.com/HHS/grants-equity/blob/main/CONTRIBUTING.md",
+  GITHUB_REPO_GOALS:
+    "https://github.com/HHS/grants-equity/blob/main/documentation/goals.md",
+  GITHUB_REPO_ROADMAP: "https://github.com/orgs/HHS/projects/12/views/2",
   GRANTS_HOME: "https://www.grants.gov",
   GRANTS_NEWSLETTER:
     "https://www.grants.gov/web/grants/connect/newsletter-archive.html",

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -7,7 +7,6 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import PageSEO from "src/components/PageSEO";
 import WtGIContent from "src/components/WtGIContent";
 import FullWidthAlert from "../components/FullWidthAlert";
-import FundingContent from "../components/FundingContent";
 import GoalContent from "../components/GoalContent";
 import Hero from "../components/Hero";
 
@@ -34,7 +33,6 @@ const Home: NextPage = () => {
         />
       </FullWidthAlert>
       <GoalContent />
-      <FundingContent />
       <WtGIContent />
     </>
   );


### PR DESCRIPTION
## Summary

Fixes #506

### Time to review: __15 mins__

## Changes proposed

- remove the NOFO content from `index` (we can deprecate/delete the `<FundingContent />` component later)
- update remaining content to not reference HHS NOFO improvement (plus a few grammar improvements) 
- add border to divide content sections (as we no longer have grey background of NOFO section)
- fix emails… 
  - replace `tbd@` with a real email
  - add new route for `equityingrants@hhs.gov` (footer and "get involved" sections should use diff emails) 
  - refactor how emails in the routes are passed to content (probably coulda separated this into its own, but couldn't help myself when fixing `tbd`) 
    - visible email address must always match the `mailto:` value
    - the value can be changed in 1 place
    - avoid passing emails in content strings; they don't need translation (yet?) 
- add more padding between content and "return to top" link
- alphabetize routes (can be discussed, but I find alpha makes stuff easier to find)

## Context for reviewers

- @itsemilyianacone and @lucasmbrown-usds should review this before merging. This change is meant primarily as a quick nix of the NOFO content. A subsequent change will more holistically improve the content — with e.g. highlights from previous research efforts, milestones, FAQs, stronger calls-to-action, etc. 

## Additional information

A couple screenshots… 

![image](https://github.com/HHS/grants-equity/assets/409279/eaf00a27-587a-42c6-a383-9b62bca66688)

![image](https://github.com/HHS/grants-equity/assets/409279/34891bb9-1f91-448d-b9d4-50176a15f08b)

<image src="https://github.com/HHS/grants-equity/assets/409279/5f5e9bb9-b1c8-40fd-b70f-58ef4d63a472" width=400 />
