### PR TITLE
[ISSUE 417] Add Autoscaling for Static site

### DIFF
--- a/infra/frontend/app-config/main.tf
+++ b/infra/frontend/app-config/main.tf
@@ -5,6 +5,7 @@ locals {
   image_repository_name           = "${local.project_name}-${local.app_name}"
   has_database                    = false
   has_incident_management_service = false
+  enable_autoscaling              = true
 
   environment_configs = { for environment in local.environments : environment => module.env_config[environment] }
   build_repository_config = {

--- a/infra/frontend/app-config/outputs.tf
+++ b/infra/frontend/app-config/outputs.tf
@@ -29,3 +29,7 @@ output "build_repository_config" {
 output "environment_configs" {
   value = local.environment_configs
 }
+
+output "enable_autoscaling" {
+  value = local.enable_autoscaling
+}

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -90,13 +90,13 @@ data "aws_ssm_parameter" "incident_management_service_integration_url" {
 }
 
 module "service" {
-  source                 = "../../modules/service"
-  service_name           = local.service_name
-  image_repository_name  = module.app_config.image_repository_name
-  image_tag              = local.image_tag
-  vpc_id                 = data.aws_vpc.default.id
-  subnet_ids             = data.aws_subnets.default.ids
-  desired_instance_count = 2
+  source                = "../../modules/service"
+  service_name          = local.service_name
+  image_repository_name = module.app_config.image_repository_name
+  image_tag             = local.image_tag
+  vpc_id                = data.aws_vpc.default.id
+  subnet_ids            = data.aws_subnets.default.ids
+  enable_autoscaling    = module.app_config.enable_autoscaling
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -6,6 +6,8 @@ resource "aws_appautoscaling_target" "ecs_target" {
   resource_id        = "service/${aws_ecs_cluster.cluster.name}/${var.service_name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
+
+  depends_on = [aws_ecs_service.app]
 }
 
 resource "aws_appautoscaling_policy" "ecs_scale_policy_cpu" {

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -2,12 +2,12 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   count               = var.enable_autoscaling ? 1 : 0
   alarm_name          = "cpu-high-${var.service_name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "60"
+  period              = "30"
   statistic           = "Average"
-  threshold           = "80"
+  threshold           = "70"
   alarm_description   = "Alarm when CPU exceeds 80%"
   alarm_actions       = [aws_appautoscaling_policy.scale_up[0].arn]
   dimensions = {
@@ -25,8 +25,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu_low" {
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "30" # You can adjust this threshold as per your needs
-  alarm_description   = "Alarm when CPU drops below 30%"
+  threshold           = "20"
+  alarm_description   = "Alarm when CPU drops below 20%"
   alarm_actions       = [aws_appautoscaling_policy.scale_down[0].arn]
   dimensions = {
     ClusterName = aws_ecs_cluster.cluster.name
@@ -39,7 +39,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
 
   max_capacity       = var.max_capacity
   min_capacity       = var.min_capacity
-  resource_id        = "service/${aws_ecs_cluster.cluster.name}/${var.service_name}" # Using the provided cluster and service names
+  resource_id        = "service/${aws_ecs_cluster.cluster.name}/${var.service_name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -1,21 +1,3 @@
-resource "aws_cloudwatch_metric_alarm" "cpu_high" {
-  count               = var.enable_autoscaling ? 1 : 0
-  alarm_name          = "cpu-high-${var.service_name}"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/ECS"
-  period              = "30"
-  statistic           = "Average"
-  threshold           = "75"
-  alarm_description   = "Alarm when CPU exceeds 75%"
-  alarm_actions       = [aws_appautoscaling_policy.scale_up[0].arn]
-  dimensions = {
-    ClusterName = aws_ecs_cluster.cluster.name
-    ServiceName = var.service_name
-  }
-}
-
 resource "aws_appautoscaling_target" "ecs_target" {
   count = var.enable_autoscaling ? 1 : 0
 
@@ -26,23 +8,21 @@ resource "aws_appautoscaling_target" "ecs_target" {
   service_namespace  = "ecs"
 }
 
-resource "aws_appautoscaling_policy" "scale_up" {
+resource "aws_appautoscaling_policy" "ecs_scale_policy_cpu" {
   count = var.enable_autoscaling ? 1 : 0
 
-  name               = "scale-up-${var.service_name}"
-  policy_type        = "StepScaling"
+  name               = "${var.service_name}-ecs-scale-policy-cpu"
+  policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.ecs_target[0].resource_id
   scalable_dimension = aws_appautoscaling_target.ecs_target[0].scalable_dimension
   service_namespace  = aws_appautoscaling_target.ecs_target[0].service_namespace
 
-  step_scaling_policy_configuration {
-    adjustment_type         = "ChangeInCapacity"
-    cooldown                = 30
-    metric_aggregation_type = "Average"
-
-    step_adjustment {
-      metric_interval_lower_bound = 0
-      scaling_adjustment          = 1
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 30
+    target_value       = 75
   }
 }

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -7,27 +7,9 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   namespace           = "AWS/ECS"
   period              = "30"
   statistic           = "Average"
-  threshold           = "70"
-  alarm_description   = "Alarm when CPU exceeds 80%"
+  threshold           = "75"
+  alarm_description   = "Alarm when CPU exceeds 75%"
   alarm_actions       = [aws_appautoscaling_policy.scale_up[0].arn]
-  dimensions = {
-    ClusterName = aws_ecs_cluster.cluster.name
-    ServiceName = var.service_name
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cpu_low" {
-  count               = var.enable_autoscaling ? 1 : 0
-  alarm_name          = "cpu-low-${var.service_name}"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/ECS"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "20"
-  alarm_description   = "Alarm when CPU drops below 20%"
-  alarm_actions       = [aws_appautoscaling_policy.scale_down[0].arn]
   dimensions = {
     ClusterName = aws_ecs_cluster.cluster.name
     ServiceName = var.service_name
@@ -55,33 +37,12 @@ resource "aws_appautoscaling_policy" "scale_up" {
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
-    cooldown                = 60
+    cooldown                = 30
     metric_aggregation_type = "Average"
 
     step_adjustment {
       metric_interval_lower_bound = 0
       scaling_adjustment          = 1
-    }
-  }
-}
-
-resource "aws_appautoscaling_policy" "scale_down" {
-  count = var.enable_autoscaling ? 1 : 0
-
-  name               = "scale-down-${var.service_name}"
-  policy_type        = "StepScaling"
-  resource_id        = aws_appautoscaling_target.ecs_target[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs_target[0].scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs_target[0].service_namespace
-
-  step_scaling_policy_configuration {
-    adjustment_type         = "ChangeInCapacity"
-    cooldown                = 60
-    metric_aggregation_type = "Average"
-
-    step_adjustment {
-      metric_interval_upper_bound = 0
-      scaling_adjustment          = -1
     }
   }
 }

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -1,0 +1,87 @@
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  count               = var.enable_autoscaling ? 1 : 0
+  alarm_name          = "cpu-high-${var.service_name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description   = "Alarm when CPU exceeds 80%"
+  alarm_actions       = [aws_appautoscaling_policy.scale_up[0].arn]
+  dimensions = {
+    ClusterName = aws_ecs_cluster.cluster.name
+    ServiceName = var.service_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_low" {
+  count               = var.enable_autoscaling ? 1 : 0
+  alarm_name          = "cpu-low-${var.service_name}"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "30" # You can adjust this threshold as per your needs
+  alarm_description   = "Alarm when CPU drops below 30%"
+  alarm_actions       = [aws_appautoscaling_policy.scale_up[0].arn]
+  dimensions = {
+    ClusterName = aws_ecs_cluster.cluster.name
+    ServiceName = var.service_name
+  }
+}
+
+resource "aws_appautoscaling_target" "ecs_target" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.cluster.name}/${var.service_name}" # Using the provided cluster and service names
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "scale_up" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  name               = "scale-up-${var.service_name}"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target[0].service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "scale_down" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  name               = "scale-down-${var.service_name}"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target[0].service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+}

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_low" {
   statistic           = "Average"
   threshold           = "30" # You can adjust this threshold as per your needs
   alarm_description   = "Alarm when CPU drops below 30%"
-  alarm_actions       = [aws_appautoscaling_policy.scale_up[0].arn]
+  alarm_actions       = [aws_appautoscaling_policy.scale_down[0].arn]
   dimensions = {
     ClusterName = aws_ecs_cluster.cluster.name
     ServiceName = var.service_name

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -68,3 +68,21 @@ variable "db_vars" {
   })
   default = null
 }
+
+variable "enable_autoscaling" {
+  description = "Flag to enable or disable auto-scaling"
+  type        = bool
+  default     = false
+}
+
+variable "max_capacity" {
+  description = "Maximum number of tasks for autoscaling"
+  type        = number
+  default     = 4
+}
+
+variable "min_capacity" {
+  description = "Minimum number of tasks for autoscaling"
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Summary
Fixes #417 

### Time to review: __5 mins__

## Changes proposed
- Add target based autoscaling triggered on CPU utilization to service module
- Enable autoscaling for frontend-dev and prod, infra provisioned

## Context for reviewers
A lot of times we will see an alarm associated with the target strategy that is warning us we have low CPU utilization. AWS knows this is a thing. There's a button to "hide autoscaling alarms". These alarms are differentiated from our monitoring alarms in that they are separate from the monitoring module entirely, and provisioned along with autoscaling. Therefore these shouldn't trigger any oncall alerts or integrate with our email integration/monitoring services via sns topics.

If you want to test the autoscaling, you use something like this to slam our service with requests over an extended period of time (credit @acouch): `ab -n 10000 -c 100 http://frontend-dev-143463875.us-east-1.elb.amazonaws.com/`

Note: Autoscaling won't save us from insane spikes in traffic that max out CPU rapidly. Likely running the above will take down some of the tasks as they fail health check. 

<img width="1507" alt="Screenshot 2023-09-21 at 4 36 48 PM" src="https://github.com/HHS/grants-equity/assets/13158571/4e2c9ee2-b8dc-484a-b945-d2e758694bdf">
<img width="1244" alt="Screenshot 2023-09-21 at 4 25 13 PM" src="https://github.com/HHS/grants-equity/assets/13158571/cc3f9fb8-5411-4f57-adc0-f78d8f4c2ec7">

## Additional information
### Service configuration view
<img width="1108" alt="Screenshot 2023-09-21 at 4 15 47 PM" src="https://github.com/HHS/grants-equity/assets/13158571/9615adf6-e1a4-40da-826b-a08ad1210f6d">

