### PR TITLE
[Issue 534] Set up HTTPS for beta

### DIFF
--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -93,6 +93,9 @@ data "aws_acm_certificate" "frontend_cert" {
   domain = "beta.grants.gov"
 }
 
+output "environment_name" {
+  value = var.environment_name
+}
 module "service" {
   source                = "../../modules/service"
   service_name          = local.service_name
@@ -101,7 +104,8 @@ module "service" {
   vpc_id                = data.aws_vpc.default.id
   subnet_ids            = data.aws_subnets.default.ids
   enable_autoscaling    = module.app_config.enable_autoscaling
-  cert_arn              = data.aws_acm_certificate.frontend_cert.arn
+  # Temporary solution to avoid issues applying SSL config to production infrastructure
+  cert_arn = var.environment_name == "dev" ? data.aws_acm_certificate.frontend_cert.arn : null
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -94,14 +94,14 @@ data "aws_acm_certificate" "frontend_cert" {
 }
 
 module "service" {
-  source                 = "../../modules/service"
-  service_name           = local.service_name
-  image_repository_name  = module.app_config.image_repository_name
-  image_tag              = local.image_tag
-  vpc_id                 = data.aws_vpc.default.id
-  subnet_ids             = data.aws_subnets.default.ids
-  enable_autoscaling     = module.app_config.enable_autoscaling
-  cert_arn               = data.aws_acm_certificate.frontend_cert.arn
+  source                = "../../modules/service"
+  service_name          = local.service_name
+  image_repository_name = module.app_config.image_repository_name
+  image_tag             = local.image_tag
+  vpc_id                = data.aws_vpc.default.id
+  subnet_ids            = data.aws_subnets.default.ids
+  enable_autoscaling    = module.app_config.enable_autoscaling
+  cert_arn              = data.aws_acm_certificate.frontend_cert.arn
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -90,7 +90,7 @@ data "aws_ssm_parameter" "incident_management_service_integration_url" {
 }
 
 data "aws_acm_certificate" "frontend_cert" {
-  domain   = "beta.grants.gov"
+  domain = "beta.grants.gov"
 }
 
 module "service" {

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -104,8 +104,9 @@ module "service" {
   vpc_id                = data.aws_vpc.default.id
   subnet_ids            = data.aws_subnets.default.ids
   enable_autoscaling    = module.app_config.enable_autoscaling
-  # Temporary solution to avoid issues applying SSL config to production infrastructure
-  cert_arn = var.environment_name == "dev" ? data.aws_acm_certificate.frontend_cert.arn : null
+  # TODO: Reroute SSL to production environment
+  # To temporarily avoid issues in production & Terratest: Check if environment is "dev" and workspace is "default"
+  cert_arn = var.environment_name == "dev" && terraform.workspace == "default" ? data.aws_acm_certificate.frontend_cert.arn : null
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -89,6 +89,10 @@ data "aws_ssm_parameter" "incident_management_service_integration_url" {
   name  = local.incident_management_service_integration_config.integration_url_param_name
 }
 
+data "aws_acm_certificate" "frontend_cert" {
+  domain   = "beta.grants.gov"
+}
+
 module "service" {
   source                 = "../../modules/service"
   service_name           = local.service_name
@@ -97,6 +101,7 @@ module "service" {
   vpc_id                 = data.aws_vpc.default.id
   subnet_ids             = data.aws_subnets.default.ids
   desired_instance_count = 2
+  cert_arn               = data.aws_acm_certificate.frontend_cert.arn
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -100,6 +100,7 @@ resource "aws_lb_listener" "alb_listener_https" {
   load_balancer_arn = aws_lb.alb.arn
   port              = 443
   protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = var.cert_arn
 
   default_action {

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -71,6 +71,42 @@ resource "aws_lb_listener_rule" "app_http_forward" {
   }
 }
 
+resource "aws_lb_listener" "alb_listener_https" {
+  count = var.cert_arn ? 1 : 0
+  load_balancer_arn = aws_lb.alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = var.cert_arn
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not Found"
+      status_code  = "404"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "app_https_forward" {
+  count = var.cert_arn ? 1 : 0
+  listener_arn = aws_lb_listener.alb_listener_https.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app_tg.arn
+  }
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+# add rule to redirect http traffic to https with the count
+
 resource "aws_lb_target_group" "app_tg" {
   # you must use a prefix, to facilitate successful tg changes
   name_prefix          = "app-"

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -59,6 +59,7 @@ resource "aws_lb_listener" "alb_listener_http" {
 resource "aws_lb_listener_rule" "redirect_http_to_https" {
   count = var.cert_arn != null ? 1 : 0
   listener_arn = aws_lb_listener.alb_listener_http.arn
+  priority = 101
 
   action {
     type = "redirect"

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -57,9 +57,9 @@ resource "aws_lb_listener" "alb_listener_http" {
 }
 
 resource "aws_lb_listener_rule" "redirect_http_to_https" {
-  count = var.cert_arn != null ? 1 : 0
+  count        = var.cert_arn != null ? 1 : 0
   listener_arn = aws_lb_listener.alb_listener_http.arn
-  priority = 101
+  priority     = 101
 
   action {
     type = "redirect"
@@ -96,7 +96,7 @@ resource "aws_lb_listener_rule" "app_http_forward" {
 
 
 resource "aws_lb_listener" "alb_listener_https" {
-  count = var.cert_arn != null ? 1 : 0
+  count             = var.cert_arn != null ? 1 : 0
   load_balancer_arn = aws_lb.alb.arn
   port              = 443
   protocol          = "HTTPS"
@@ -114,7 +114,7 @@ resource "aws_lb_listener" "alb_listener_https" {
 }
 
 resource "aws_lb_listener_rule" "app_https_forward" {
-  count = var.cert_arn != null ? 1 : 0
+  count        = var.cert_arn != null ? 1 : 0
   listener_arn = aws_lb_listener.alb_listener_https[0].arn
   priority     = 100
 
@@ -128,8 +128,6 @@ resource "aws_lb_listener_rule" "app_https_forward" {
     }
   }
 }
-
-# add rule to redirect http traffic to https with the count
 
 resource "aws_lb_target_group" "app_tg" {
   # you must use a prefix, to facilitate successful tg changes

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -56,6 +56,27 @@ resource "aws_lb_listener" "alb_listener_http" {
   }
 }
 
+resource "aws_lb_listener_rule" "redirect_http_to_https" {
+  count = var.cert_arn != null ? 1 : 0
+  listener_arn = aws_lb_listener.alb_listener_http.arn
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
 resource "aws_lb_listener_rule" "app_http_forward" {
   listener_arn = aws_lb_listener.alb_listener_http.arn
   priority     = 100
@@ -71,8 +92,10 @@ resource "aws_lb_listener_rule" "app_http_forward" {
   }
 }
 
+
+
 resource "aws_lb_listener" "alb_listener_https" {
-  count = var.cert_arn ? 1 : 0
+  count = var.cert_arn != null ? 1 : 0
   load_balancer_arn = aws_lb.alb.arn
   port              = 443
   protocol          = "HTTPS"
@@ -90,8 +113,8 @@ resource "aws_lb_listener" "alb_listener_https" {
 }
 
 resource "aws_lb_listener_rule" "app_https_forward" {
-  count = var.cert_arn ? 1 : 0
-  listener_arn = aws_lb_listener.alb_listener_https.arn
+  count = var.cert_arn != null ? 1 : 0
+  listener_arn = aws_lb_listener.alb_listener_https[0].arn
   priority     = 100
 
   action {

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -29,6 +29,14 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "Allow HTTPS traffic from public internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     description = "Allow all outgoing traffic"
     from_port   = 0

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -28,8 +28,8 @@ resource "aws_security_group" "alb" {
   }
 }
 
- # TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
-  # checkov:skip=CKV_AWS_260:Disallow ingress from 0.0.0.0:0 to port 80 when implementing HTTPS support in issue #163
+# TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
+# checkov:skip=CKV_AWS_260:Disallow ingress from 0.0.0.0:0 to port 80 when implementing HTTPS support in issue #163
 resource "aws_security_group_rule" "http_ingress" {
   security_group_id = aws_security_group.alb.id
 

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -29,14 +29,6 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    description = "Allow HTTPS traffic from public internet"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   egress {
     description = "Allow all outgoing traffic"
     from_port   = 0
@@ -44,6 +36,18 @@ resource "aws_security_group" "alb" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+}
+
+resource "aws_security_group_rule" "https_ingress" {
+  count             = var.cert_arn != null ? 1 : 0
+  security_group_id = aws_security_group.alb.id
+
+  description = "Allow HTTPS traffic from public internet"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  type        = "ingress"
 }
 
 # Security group to allow access to Fargate tasks

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -28,9 +28,10 @@ resource "aws_security_group" "alb" {
   }
 }
 
-# TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
-# checkov:skip=CKV_AWS_260:Disallow ingress from 0.0.0.0:0 to port 80 when implementing HTTPS support in issue #163
 resource "aws_security_group_rule" "http_ingress" {
+  # TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
+  # checkov:skip=CKV_AWS_260:Disallow ingress from 0.0.0.0:0 to port 80 when implementing HTTPS support in issue #163
+
   security_group_id = aws_security_group.alb.id
 
   description = "Allow HTTP traffic from public internet"

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -19,16 +19,6 @@ resource "aws_security_group" "alb" {
 
   vpc_id = var.vpc_id
 
-  # TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
-  # checkov:skip=CKV_AWS_260:Disallow ingress from 0.0.0.0:0 to port 80 when implementing HTTPS support in issue #163
-  ingress {
-    description = "Allow HTTP traffic from public internet"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   egress {
     description = "Allow all outgoing traffic"
     from_port   = 0
@@ -36,6 +26,19 @@ resource "aws_security_group" "alb" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+}
+
+ # TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
+  # checkov:skip=CKV_AWS_260:Disallow ingress from 0.0.0.0:0 to port 80 when implementing HTTPS support in issue #163
+resource "aws_security_group_rule" "http_ingress" {
+  security_group_id = aws_security_group.alb.id
+
+  description = "Allow HTTP traffic from public internet"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  type        = "ingress"
 }
 
 resource "aws_security_group_rule" "https_ingress" {

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -68,3 +68,9 @@ variable "db_vars" {
   })
   default = null
 }
+
+variable "cert_arn" {
+  description = "The ARN for the TLS certificate passed in from the app service layer"
+  type = string
+  default = null
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -71,8 +71,8 @@ variable "db_vars" {
 
 variable "cert_arn" {
   description = "The ARN for the TLS certificate passed in from the app service layer"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "enable_autoscaling" {

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -93,14 +93,3 @@ resource "aws_vpc_endpoint" "aws_service" {
   subnet_ids          = data.aws_subnets.default.ids
   private_dns_enabled = true
 }
-
-data "aws_ssm_parameter" "tls_private_key" {
-  name = "/lb/frontend-dev/tls-private-key"
-}
-data "aws_ssm_parameter" "tls_cert" {
-  name = "/lb/frontend-dev/tls-cert"
-}
-
-data "aws_ssm_parameter" "tls_cert_chain" {
-  name = "/lb/frontend-dev/tls-cert-chain"
-}

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -104,4 +104,8 @@ data "aws_ssm_parameter" "tls_cert" {
 resource "aws_acm_certificate" "dev_frontend_cert" {
   private_key      = data.aws_ssm_parameter.tls_private_key
   certificate_body = data.aws_ssm_parameter.tls_cert
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -93,3 +93,15 @@ resource "aws_vpc_endpoint" "aws_service" {
   subnet_ids          = data.aws_subnets.default.ids
   private_dns_enabled = true
 }
+
+data "aws_ssm_parameter" "tls_private_key" {
+  name = "/lb/frontend-dev/tls-private-key"
+}
+data "aws_ssm_parameter" "tls_cert" {
+  name = "/lb/frontend-dev/tls-cert"
+}
+
+resource "aws_acm_certificate" "dev_frontend_cert" {
+  private_key      = data.aws_ssm_parameter.tls_private_key
+  certificate_body = data.aws_ssm_parameter.tls_cert
+}

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -101,11 +101,6 @@ data "aws_ssm_parameter" "tls_cert" {
   name = "/lb/frontend-dev/tls-cert"
 }
 
-resource "aws_acm_certificate" "dev_frontend_cert" {
-  private_key      = data.aws_ssm_parameter.tls_private_key.value
-  certificate_body = data.aws_ssm_parameter.tls_cert.value
-
-  lifecycle {
-    create_before_destroy = true
-  }
+data "aws_ssm_parameter" "tls_cert_chain" {
+  name = "/lb/frontend-dev/tls-cert-chain"
 }

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -102,8 +102,8 @@ data "aws_ssm_parameter" "tls_cert" {
 }
 
 resource "aws_acm_certificate" "dev_frontend_cert" {
-  private_key      = data.aws_ssm_parameter.tls_private_key
-  certificate_body = data.aws_ssm_parameter.tls_cert
+  private_key      = data.aws_ssm_parameter.tls_private_key.value
+  certificate_body = data.aws_ssm_parameter.tls_cert.value
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Summary
Fixes #534 

### Time to review: __15 mins__

## Changes proposed
- Load cert to load balancer for frontend by domain
- Create HTTPs listener and forward/redirect rules
- Security group ingress for port 443

## Context for reviewers
- We will need to apply account changes first to get acm imported via the networks/main.tf module.
- We need to make sure the backend won't break without a cert
- We need to make sure to redirect via https if the cert exists


