### PR TITLE
[Issue 573] Update next to fix build and temporarily ignore postcss vuln

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -67,7 +67,8 @@ VOLUME ["/frontend/.next/cache/images/"]
 # https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
 RUN apk add --no-cache wget=1.21.4-r0 \
 # Necessary for installing sharp
-  build-base=0.5-r3
+  build-base=0.5-r3 \
+  openssl=3.1.3-r0
 
 # Remove dev dependencies after build
 RUN npm prune --production


### PR DESCRIPTION
## Summary
Fixes #573

### Time to review: __10 mins__

## Changes proposed
The PR #573 upgraded next, however the static site won't build in the release target because of the issue described here: https://github.com/i18next/next-i18next/issues/2214 . This downgrades next from `13.5.4` to `13.5.3` to fix the issue.

This also temporarily white-lists `postcss`, which is fixed in next `13.5.4` by upgrading postcss. 
