### PR TITLE
revert dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # This file is largely based on the template-application-flask Dockerfile and
 # Next.js Docker example: https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose
 # =============================================================================
-FROM node:20-alpine AS base
+FROM node:20-bullseye-slim AS base
 WORKDIR /frontend
 
 # Install dependencies
@@ -56,18 +56,20 @@ RUN npm run build -- --no-lint
 # Run the Next.js server
 # =====================================
 # Use clean image for release, excluding any unnecessary files or dependencies
-FROM node:20-alpine AS release
+FROM node:20-bullseye-slim AS release
 WORKDIR /frontend
 
 RUN mkdir -p /frontend/.next/cache/images/
 VOLUME ["/frontend/.next/cache/images/"]
 
-# Install wget for health checks
-# no-cache removes need to rm cache dir
-# https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
-RUN apk add --no-cache wget=1.21.4-r0 \
-# Necessary for installing sharp
-  build-base=0.5-r3
+RUN apt-get update \
+  # Install security updates
+  # https://pythonspeed.com/articles/security-updates-in-docker/
+  && apt-get upgrade --yes \
+  # Install wget, required for health checks
+  wget \
+  # Reduce the image size by clearing apt cached lists
+  && rm -fr /var/lib/apt/lists/*
 
 # Remove dev dependencies after build
 RUN npm prune --production


### PR DESCRIPTION
## Summary
Fixes #588 

### Time to review: __5 mins__

## Changes proposed
We updated the docker image and node version because of vulnerabilities, but now the health checks are failing. 
Maybe this can bring things back online.
* Keep node version 20?
* Move from alpine to bullseye slim

## Context for reviewers
If vulnerability tests and terratest passes, the only way to verify is by deploying to ecs.
