### PR TITLE
[ISSUE 586] Fix ci-infra-service.yml to work for api too, not just frontend

### DIFF
--- a/.github/workflows/ci-infra-service-api.yml
+++ b/.github/workflows/ci-infra-service-api.yml
@@ -1,0 +1,23 @@
+name: CI Frontend Infra Service Checks
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - infra/frontend/service/**
+      - infra/test/**
+      - .github/workflows/ci-infra-service.yml
+  pull_request:
+    paths:
+      - infra/frontend/service/**
+      - infra/test/**
+      - .github/workflows/ci-infra-service.yml
+  workflow_dispatch:
+
+jobs:
+  infra-service-checks:
+    name: Infra Service Checks
+    uses: ./.github/workflows/infra-service.yml
+    with:
+      app_name: frontend

--- a/.github/workflows/ci-infra-service-api.yml
+++ b/.github/workflows/ci-infra-service-api.yml
@@ -1,16 +1,16 @@
-name: CI Frontend Infra Service Checks
+name: CI API Infra Service Checks
 
 on:
   push:
     branches:
       - main
     paths:
-      - infra/frontend/service/**
+      - infra/api/service/**
       - infra/test/**
       - .github/workflows/ci-infra-service.yml
   pull_request:
     paths:
-      - infra/frontend/service/**
+      - infra/api/service/**
       - infra/test/**
       - .github/workflows/ci-infra-service.yml
   workflow_dispatch:
@@ -20,4 +20,4 @@ jobs:
     name: Infra Service Checks
     uses: ./.github/workflows/infra-service.yml
     with:
-      app_name: frontend
+      app_name: api

--- a/.github/workflows/ci-infra-service-frontend.yml
+++ b/.github/workflows/ci-infra-service-frontend.yml
@@ -1,0 +1,23 @@
+name: CI API Infra Service Checks
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - infra/api/service/**
+      - infra/test/**
+      - .github/workflows/ci-infra-service.yml
+  pull_request:
+    paths:
+      - infra/api/service/**
+      - infra/test/**
+      - .github/workflows/ci-infra-service.yml
+  workflow_dispatch:
+
+jobs:
+  infra-service-checks:
+    name: Infra Service Checks
+    uses: ./.github/workflows/infra-service.yml
+    with:
+      app_name: api

--- a/.github/workflows/ci-infra-service-frontend.yml
+++ b/.github/workflows/ci-infra-service-frontend.yml
@@ -1,16 +1,16 @@
-name: CI API Infra Service Checks
+name: CI Frontend Infra Service Checks
 
 on:
   push:
     branches:
       - main
     paths:
-      - infra/api/service/**
+      - infra/frontend/service/**
       - infra/test/**
       - .github/workflows/ci-infra-service.yml
   pull_request:
     paths:
-      - infra/api/service/**
+      - infra/frontend/service/**
       - infra/test/**
       - .github/workflows/ci-infra-service.yml
   workflow_dispatch:
@@ -20,4 +20,4 @@ jobs:
     name: Infra Service Checks
     uses: ./.github/workflows/infra-service.yml
     with:
-      app_name: api
+      app_name: frontend

--- a/.github/workflows/infra-service.yml
+++ b/.github/workflows/infra-service.yml
@@ -8,9 +8,6 @@ on:
         required: true
         type: string
 
-env:
-  APP_NAME: frontend
-
 jobs:
   infra-test-e2e:
     name: Test service
@@ -35,9 +32,9 @@ jobs:
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials
         with:
-          app_name: ${{ env.APP_NAME }}
+          app_name: ${{ inputs.app_name }}
           # Run infra CI on dev environment
           environment: dev
 
       - name: Run Terratest
-        run: make APP_NAME=${{ env.APP_NAME }} infra-test-service
+        run: make APP_NAME=${{ inputs.app_name }} infra-test-service

--- a/.github/workflows/infra-service.yml
+++ b/.github/workflows/infra-service.yml
@@ -1,19 +1,12 @@
-name: CI Infra Service Checks
+name: Infra Service Checks
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - infra/*/service/**
-      - infra/test/**
-      - .github/workflows/ci-infra-service.yml
-  pull_request:
-    paths:
-      - infra/*/service/**
-      - infra/test/**
-      - .github/workflows/ci-infra-service.yml
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
 
 env:
   APP_NAME: frontend

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -1,7 +1,7 @@
 # GitHub Actions CI workflow that runs vulnerability scans on the application's Docker image
 # to ensure images built are secure before they are deployed.
 
-name: CI Vulnerability Scans
+name: Vulnerability Scans
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary
Fixes #586

### Time to review: __3 mins__

## Changes proposed
- Move jobs for infra service into their own callable workflow
- Create ci-infra-service-frontend.yml and ci-infra-service-api.yml to run checks for frontend and api respectively

## Context for reviewers
We were only running infra checks for frontend, let's run them for api too.